### PR TITLE
Fix binary generation with list

### DIFF
--- a/erlang-squid/src/main/java/org/sonar/erlang/parser/ErlangGrammarImpl.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/parser/ErlangGrammarImpl.java
@@ -623,9 +623,9 @@ public enum ErlangGrammarImpl implements GrammarRuleKey {
     b.rule(macroLiteralVarName).is(questionmark, questionmark, identifier);
 
     b.rule(tupleLiteral).is(lcurlybrace, b.zeroOrMore(b.firstOf(comma, expression)), rcurlybrace);
-    b.rule(binaryLiteral).is(binstart, b.firstOf(b.sequence(b.sequence(assignmentExpression, listcomp,
+    b.rule(binaryLiteral).is(b.firstOf(lbracket, binstart), b.firstOf(b.sequence(b.sequence(assignmentExpression, listcomp,
       b.oneOrMore(binaryQualifier)), b.zeroOrMore(b.firstOf(comma, assignmentExpression))), b.zeroOrMore(b.firstOf(
-      comma, binaryElement))), binend);
+      comma, binaryElement))), b.firstOf(binend, rbracket));
     b.rule(binaryQualifier).is(b.firstOf(
       b.sequence(binaryLiteral, doublearrowback, expression), b.sequence(
         primaryExpression, arrowback, expression, b.zeroOrMore(comma, expression)

--- a/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangParserBinaryExpressionTest.java
+++ b/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangParserBinaryExpressionTest.java
@@ -43,8 +43,10 @@ public class ErlangParserBinaryExpressionTest {
       .matches("<< << X:8, 0:8/utf8 >> || << X >> <= << 1, A, 3 >> >>")
       .matches("<<\n?MAGIC,\nVersion:?BYTE,\nType:?BYTE,\n>>")
       .matches("<< << (X*2) >> || <<X>> <= << 1,2,3 >> >>")
+      .matches("[ << (X*2) >> || <<X>> <= << 1,2,3 >> ]")
       .matches("<< << (X*2) >> || <<X>> <= method1() >>")
       .matches("<< << (X*2) >> || <<X>> <= method1(), method2() >>")
+      .matches("[ << (X*2) >> || <<X>> <= method1(), method2() ]")
       .matches("<<Part1:4/big-unsigned-integer-unit:8," +
         "Part2:4/big-unsigned-integer-unit:8," +
         "Body/binary>>")


### PR DESCRIPTION
Fix binary generation when using bit string generator and list like:
    [ << (X*2) >> || <<X>> <= << 1,2,3 >> ]