### PR TITLE
Partially fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,11 @@ language: java
 sudo: false
 
 jdk:
-  - oraclejdk7
+  - oraclejdk8
 
 install: true
 script: ./travis.sh
+
 env:
   - TARGET=CI
   - TARGET=IT SQ_VERSION=DEV

--- a/travis.sh
+++ b/travis.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-set -euo pipefail
+set -euox pipefail
 
 function installTravisTools {
-  mkdir ~/.local
-  curl -sSL https://github.com/SonarSource/travis-utils/tarball/v21 | tar zx --strip-components 1 -C ~/.local
+  mkdir -p ~/.local
+  curl -sSL https://github.com/SonarSource/travis-utils/tarball/v47 | tar zx --strip-components 1 -C ~/.local
   source ~/.local/bin/install
 }
 
@@ -33,4 +33,3 @@ IT)
   ;;
 
 esac
-


### PR DESCRIPTION
- Don't fail build if ~/.local already exists
- Output shell commands for easier debugging
- Use oraclejdk8 because it's required by SonarQube LTS now
- Use latest travis-utils