### PR TITLE
bump version to 1.4-SNAPSHOT in child pom.xmls

### DIFF
--- a/erlang-checks/pom.xml
+++ b/erlang-checks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.codehaus.sonar-plugins.erlang</groupId>
     <artifactId>erlang</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>1.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>erlang-checks</artifactId>

--- a/erlang-squid/pom.xml
+++ b/erlang-squid/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.codehaus.sonar-plugins.erlang</groupId>
     <artifactId>erlang</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>1.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>erlang-squid</artifactId>

--- a/sonar-erlang-plugin/pom.xml
+++ b/sonar-erlang-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.sonar-plugins.erlang</groupId>
     <artifactId>erlang</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>1.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-erlang-plugin</artifactId>

--- a/sslr-erlang-toolkit/pom.xml
+++ b/sslr-erlang-toolkit/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.codehaus.sonar-plugins.erlang</groupId>
     <artifactId>erlang</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>1.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>sslr-erlang-toolkit</artifactId>


### PR DESCRIPTION
Without this, I get errors during compilation:

~~~
[ERROR]   The project org.codehaus.sonar-plugins.erlang:erlang-squid:1.3-SNAPSHOT (/home/denes/projects/sonar-erlang/erlang-squid/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM: Could not find artifact org.codehaus.sonar-plugins.erlang:erlang:pom:1.3-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 4, column 11 -> [Help 2]
[ERROR]   
[ERROR]   The project org.codehaus.sonar-plugins.erlang:sslr-erlang-toolkit:1.3-SNAPSHOT (/home/denes/projects/sonar-erlang/sslr-erlang-toolkit/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM: Could not find artifact org.codehaus.sonar-plugins.erlang:erlang:pom:1.3-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 4, column 11 -> [Help 2]
[ERROR]   
[ERROR]   The project org.codehaus.sonar-plugins.erlang:erlang-checks:1.3-SNAPSHOT (/home/denes/projects/sonar-erlang/erlang-checks/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM: Could not find artifact org.codehaus.sonar-plugins.erlang:erlang:pom:1.3-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 4, column 11 -> [Help 2]
[ERROR]   
[ERROR]   The project org.codehaus.sonar-plugins.erlang:sonar-erlang-plugin:1.3-SNAPSHOT (/home/denes/projects/sonar-erlang/sonar-erlang-plugin/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM: Could not find artifact org.codehaus.sonar-plugins.erlang:erlang:pom:1.3-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 5, column 11 -> [Help 2]
~~~