### PR TITLE
Add rebar3 common test, xref and dialyzer report parsers

### DIFF
--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/BlockSeparatorCharacterCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/BlockSeparatorCharacterCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/BranchesOfRecursionCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/BranchesOfRecursionCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/CheckList.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/CheckList.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/CommentContainsPatternChecker.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/CommentContainsPatternChecker.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/CommentRegularExpressionCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/CommentRegularExpressionCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/DepthOfCasesCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/DepthOfCasesCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/DoNotUseEmptyFlowControlCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/DoNotUseEmptyFlowControlCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/DoNotUseExportAllCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/DoNotUseExportAllCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/DoNotUseImportCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/DoNotUseImportCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/ExportOneFunctionPerLineCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/ExportOneFunctionPerLineCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/FixmeCommentCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/FixmeCommentCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/FunExpressionComplexityCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/FunExpressionComplexityCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/FunctionComplexityCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/FunctionComplexityCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/FunctionDefAndClausesSeparationCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/FunctionDefAndClausesSeparationCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/FunctionLengthCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/FunctionLengthCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/IndentionSizeCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/IndentionSizeCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/IsTailRecursiveCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/IsTailRecursiveCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/LineLengthCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/LineLengthCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/MethodMustHaveSpecs.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/MethodMustHaveSpecs.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/MultipleBlankLinesCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/MultipleBlankLinesCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/NoEmacsStyleLeadingCommasCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/NoEmacsStyleLeadingCommasCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/NoMacrosCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/NoMacrosCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/NoSpaceAfterBeforeBracketsCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/NoSpaceAfterBeforeBracketsCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/NoTabsForIndentionCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/NoTabsForIndentionCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/NoTrailingWhitespaceCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/NoTrailingWhitespaceCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/NumberOfFunctionArgsCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/NumberOfFunctionArgsCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/ParsingErrorCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/ParsingErrorCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/SpaceAfterBeforeOperatorsCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/SpaceAfterBeforeOperatorsCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/TodoCommentCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/TodoCommentCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/XPathCheck.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/XPathCheck.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/main/java/org/sonar/erlang/checks/package-info.java
+++ b/erlang-checks/src/main/java/org/sonar/erlang/checks/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/BlockSeparatorCharacterCheckTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/BlockSeparatorCharacterCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/BranchesOfRecursionCheckTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/BranchesOfRecursionCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/CommentRegularExpressionCheckTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/CommentRegularExpressionCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/DepthOfCasesCheckTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/DepthOfCasesCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/DoNotUseEmptyFlowControlCheckTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/DoNotUseEmptyFlowControlCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/DoNotUseExportAllTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/DoNotUseExportAllTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/DoNotUseImportTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/DoNotUseImportTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/ExportOneFunctionPerLineTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/ExportOneFunctionPerLineTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/FixmeCommentCheckTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/FixmeCommentCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/FunExpressionComplexityCheckTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/FunExpressionComplexityCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/FunctionComplexityCheckTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/FunctionComplexityCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/FunctionDefAndClausesSeparationCheckTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/FunctionDefAndClausesSeparationCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/FunctionLengthCheckTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/FunctionLengthCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/IndentionSizeCheckTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/IndentionSizeCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/IsTailRecursiveCheckTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/IsTailRecursiveCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/LineLengthCheckTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/LineLengthCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/MethodMustHaveSpecsTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/MethodMustHaveSpecsTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/MultipleBlankLinesCheckTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/MultipleBlankLinesCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/NoEmacsStyleLeadingCommasTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/NoEmacsStyleLeadingCommasTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/NoMacrosTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/NoMacrosTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/NoSpaceAfterBeforeBracketsCheckTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/NoSpaceAfterBeforeBracketsCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/NoTabsForIndentionCheckTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/NoTabsForIndentionCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/NoTrailingWhitespaceCheckTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/NoTrailingWhitespaceCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/NumberOfFunctionArgsCheckTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/NumberOfFunctionArgsCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/ParsingErrorCheckTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/ParsingErrorCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/SpaceAfterBeforeOperatorsCheckTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/SpaceAfterBeforeOperatorsCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/TestHelper.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/TestHelper.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/TodoCommentCheckTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/TodoCommentCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-checks/src/test/java/org/sonar/erlang/checks/XPathCheckTest.java
+++ b/erlang-checks/src/test/java/org/sonar/erlang/checks/XPathCheckTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/main/java/org/sonar/erlang/ErlangAstScanner.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/ErlangAstScanner.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/main/java/org/sonar/erlang/ErlangCommentAnalyser.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/ErlangCommentAnalyser.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/main/java/org/sonar/erlang/ErlangConfiguration.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/ErlangConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/main/java/org/sonar/erlang/api/ErlangKeyword.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/api/ErlangKeyword.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/main/java/org/sonar/erlang/api/ErlangMetric.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/api/ErlangMetric.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/main/java/org/sonar/erlang/api/ErlangPunctuator.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/api/ErlangPunctuator.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/main/java/org/sonar/erlang/api/package-info.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/api/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/main/java/org/sonar/erlang/metrics/BranchesOfRecursion.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/metrics/BranchesOfRecursion.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/main/java/org/sonar/erlang/metrics/ErlangComplexityVisitor.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/metrics/ErlangComplexityVisitor.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/main/java/org/sonar/erlang/metrics/ErlangStatementVisitor.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/metrics/ErlangStatementVisitor.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/main/java/org/sonar/erlang/metrics/ImportedModules.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/metrics/ImportedModules.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/main/java/org/sonar/erlang/metrics/IncludedFiles.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/metrics/IncludedFiles.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/main/java/org/sonar/erlang/metrics/MaxDepthOfCalling.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/metrics/MaxDepthOfCalling.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/main/java/org/sonar/erlang/metrics/NumberOfFunctionArgument.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/metrics/NumberOfFunctionArgument.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/main/java/org/sonar/erlang/metrics/NumberOfRecords.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/metrics/NumberOfRecords.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/main/java/org/sonar/erlang/metrics/PublicDocumentedApiCounter.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/metrics/PublicDocumentedApiCounter.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/main/java/org/sonar/erlang/metrics/package-info.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/metrics/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/main/java/org/sonar/erlang/package-info.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/main/java/org/sonar/erlang/parser/ErlangGrammarImpl.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/parser/ErlangGrammarImpl.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/main/java/org/sonar/erlang/parser/package-info.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/parser/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/test/java/org/sonar/erlang/ErlangAstScannerTest.java
+++ b/erlang-squid/src/test/java/org/sonar/erlang/ErlangAstScannerTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/test/java/org/sonar/erlang/ErlangCommentAnalyserTest.java
+++ b/erlang-squid/src/test/java/org/sonar/erlang/ErlangCommentAnalyserTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/test/java/org/sonar/erlang/TestHelper.java
+++ b/erlang-squid/src/test/java/org/sonar/erlang/TestHelper.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangParserBinaryExpressionTest.java
+++ b/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangParserBinaryExpressionTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangParserCaseStatementTest.java
+++ b/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangParserCaseStatementTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangParserExpressionTest.java
+++ b/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangParserExpressionTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangParserFunctionCallExpressionTest.java
+++ b/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangParserFunctionCallExpressionTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangParserIfExpressionTest.java
+++ b/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangParserIfExpressionTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangParserLowLevelTest.java
+++ b/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangParserLowLevelTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangParserModulesTest.java
+++ b/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangParserModulesTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangParserStatementTest.java
+++ b/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangParserStatementTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangRealCodeTest.java
+++ b/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangRealCodeTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangRecordDefinitionTest.java
+++ b/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangRecordDefinitionTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/erlang-squid/src/test/java/org/sonar/erlang/parser/ModuleAttributesTest.java
+++ b/erlang-squid/src/test/java/org/sonar/erlang/parser/ModuleAttributesTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/plugin/pom.xml
+++ b/its/plugin/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>org.sonarsource.orchestrator</groupId>
       <artifactId>sonar-orchestrator</artifactId>
-      <version>3.10.1</version>
+      <version>3.13</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
   <properties>
     <license.title>SonarQube Erlang Plugin</license.title>
     <license.mailto>kende.tamas@gmail.com</license.mailto>
-    <license.owner>Tamas Kende</license.owner>
-    <license.years>2012-2017</license.years>
+    <license.owner>Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)</license.owner>
+    <license.years>2012-2018</license.years>
 
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
 

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/ErlangCpdVisitor.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/ErlangCpdVisitor.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/ErlangHighlighter.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/ErlangHighlighter.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/ErlangPlugin.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/ErlangPlugin.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/ErlangPlugin.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/ErlangPlugin.java
@@ -30,6 +30,8 @@ import org.sonar.plugins.erlang.cover.CoverCoverageSensor;
 import org.sonar.plugins.erlang.dialyzer.DialyzerRuleDefinition;
 import org.sonar.plugins.erlang.dialyzer.DialyzerSensor;
 import org.sonar.plugins.erlang.eunit.EunitXmlSensor;
+import org.sonar.plugins.erlang.xref.XrefRuleDefinition;
+import org.sonar.plugins.erlang.xref.XrefSensor;
 
 @Properties({
   @Property(
@@ -49,6 +51,12 @@ import org.sonar.plugins.erlang.eunit.EunitXmlSensor;
     defaultValue = ErlangPlugin.DIALYZER_DEFAULT_FILENAME,
     name = "Dialyzer Default Filename",
     description = "Filename of the dialyzer output located in the eunit folder",
+    global = true, project = true),
+
+  @Property(key = ErlangPlugin.XREF_FILENAME_KEY,
+    defaultValue = ErlangPlugin.XREF_DEFAULT_FILENAME,
+    name = "Xref Default Filename",
+    description = "Filename of the xref output located in the eunit folder",
     global = true, project = true),
 
   @Property(key = ErlangPlugin.COVERDATA_FILENAME_KEY,
@@ -71,6 +79,9 @@ public class ErlangPlugin implements Plugin {
   public static final String DIALYZER_FILENAME_KEY = "sonar.erlang.dialyzer.filename";
   public static final String DIALYZER_DEFAULT_FILENAME = "dialyzer.log";
 
+  public static final String XREF_FILENAME_KEY = "sonar.erlang.xref.filename";
+  public static final String XREF_DEFAULT_FILENAME = "xref.log";
+
   public static final String COVERDATA_FILENAME_KEY = "sonar.erlang.coverdata.filename";
   public static final String COVERDATA_DEFAULT_FILENAME = "eunit.coverdata";
 
@@ -92,6 +103,7 @@ public class ErlangPlugin implements Plugin {
 
             ErlangChecksRuleDefinition.class,
             DialyzerRuleDefinition.class,
+            XrefRuleDefinition.class,
             ErlangProfile.class,
 
             EunitXmlSensor.class,
@@ -99,6 +111,7 @@ public class ErlangPlugin implements Plugin {
             CoverCoverageSensor.class,
 
             DialyzerSensor.class,
+            XrefSensor.class,
 
             PropertyDefinition.builder(FILE_SUFFIXES_KEY)
                     .defaultValue(EXTENSION)

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/ErlangProfile.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/ErlangProfile.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/ErlangSquidSensor.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/ErlangSquidSensor.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/checks/ErlangChecksRuleDefinition.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/checks/ErlangChecksRuleDefinition.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/checks/package-info.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/checks/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/core/Erlang.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/core/Erlang.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/core/package-info.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/core/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/cover/CoverCoverageSensor.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/cover/CoverCoverageSensor.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/cover/CoverDataFileParser.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/cover/CoverDataFileParser.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/cover/ErlangFileCoverage.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/cover/ErlangFileCoverage.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/cover/FixedOtpInputStream.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/cover/FixedOtpInputStream.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/cover/GenericExtFilter.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/cover/GenericExtFilter.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/cover/LCOVParser.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/cover/LCOVParser.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/cover/package-info.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/cover/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/dialyzer/DialyzerReportParser.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/dialyzer/DialyzerReportParser.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/dialyzer/DialyzerReportParser.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/dialyzer/DialyzerReportParser.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.plugins.erlang.dialyzer;
 
+import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.InputFile;
@@ -87,7 +88,7 @@ public class DialyzerReportParser {
         RuleKey ruleKey = RuleKey.of(REPO_KEY, key);
         ActiveRule rule = context.activeRules().find(ruleKey);
         if (rule != null) {
-            String filePattern = "**/"+fileName;
+            String filePattern = "**/" + FilenameUtils.getName(fileName);
             InputFile inputFile = context.fileSystem().inputFile(
                     context.fileSystem().predicates().matchesPathPattern(filePattern));
             if (inputFile != null) {

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/dialyzer/DialyzerRuleDefinition.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/dialyzer/DialyzerRuleDefinition.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/dialyzer/DialyzerSensor.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/dialyzer/DialyzerSensor.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/dialyzer/ErlangRule.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/dialyzer/ErlangRule.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/dialyzer/ErlangRuleManager.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/dialyzer/ErlangRuleManager.java
@@ -29,12 +29,12 @@ public class ErlangRuleManager  {
   private static final String OTHER_RULES_KEY = "OTHER_RULES";
   public static final String UNUSED_NAMES_KEY = "UNUSED_NAMES";
 
-  ErlangRuleManager(String rulesPath) {
+  public ErlangRuleManager(String rulesPath) {
     rules = new ErlangXmlRuleParser().parse(ErlangRuleManager.class
       .getResourceAsStream(rulesPath));
   }
 
-  String getRuleKeyByMessage(String message) {
+  public String getRuleKeyByMessage(String message) {
     for (ErlangRule rule : rules) {
       if (rule.hasMessage(message)) {
         return rule.getRule().getKey();

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/dialyzer/ErlangRuleManager.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/dialyzer/ErlangRuleManager.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/dialyzer/ErlangXmlRuleParser.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/dialyzer/ErlangXmlRuleParser.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/dialyzer/RuleHandler.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/dialyzer/RuleHandler.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/dialyzer/package-info.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/dialyzer/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/eunit/EunitTestCase.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/eunit/EunitTestCase.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/eunit/EunitTestsuite.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/eunit/EunitTestsuite.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.plugins.erlang.eunit;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
@@ -27,7 +28,8 @@ import org.sonar.api.batch.fs.InputFile;
 import java.util.ArrayList;
 import java.util.List;
 
-@JacksonXmlRootElement(localName = "testuite")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JacksonXmlRootElement(localName = "testsuite")
 public class EunitTestsuite {
   @JacksonXmlProperty(isAttribute = true)
   private int errors;
@@ -45,7 +47,7 @@ public class EunitTestsuite {
   private float time;
 
   @JacksonXmlProperty(isAttribute = true)
-  private String name;
+  private String name = "";
 
   @JacksonXmlProperty(localName = "testcase")
   @JacksonXmlElementWrapper(useWrapping = false)

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/eunit/EunitTestsuite.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/eunit/EunitTestsuite.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/eunit/EunitTestsuite.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/eunit/EunitTestsuite.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import org.sonar.api.batch.fs.InputFile;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -66,6 +67,10 @@ public class EunitTestsuite {
     return name.replaceAll(".*'(.*?)'.*", "$1");
   }
 
+  public String getApp() {
+    return name.replaceAll("file \"(.*?)\\.app\"", "$1");
+  }
+
   public int getErrors() {
     return errors;
   }
@@ -88,7 +93,8 @@ public class EunitTestsuite {
 
   public static EunitTestsuite find(InputFile file, List<EunitTestsuite> testReports) {
     for (EunitTestsuite testReport : testReports) {
-      if (file.absolutePath().endsWith(testReport.getModule() + ".erl")) {
+      if (file.absolutePath().endsWith(File.separator + testReport.getModule() + ".erl")
+              || file.absolutePath().endsWith(File.separator + testReport.getApp() + ".erl")) {
         return testReport;
       }
     }

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/eunit/EunitTestsuite.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/eunit/EunitTestsuite.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import org.sonar.api.batch.fs.InputFile;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -49,19 +48,6 @@ public class EunitTestsuite {
 
   @JacksonXmlProperty(isAttribute = true)
   private String name = "";
-
-  @JacksonXmlProperty(localName = "testcase")
-  @JacksonXmlElementWrapper(useWrapping = false)
-  private List<EunitTestCase> indexByClassname;
-
-  public EunitTestsuite() {
-    this.indexByClassname = new ArrayList<>();
-  }
-
-
-  public List<EunitTestCase> getIndexByClassname() {
-    return indexByClassname;
-  }
 
   public String getModule() {
     return name.replaceAll(".*'(.*?)'.*", "$1");

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/eunit/EunitTestsuites.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/eunit/EunitTestsuites.java
@@ -1,0 +1,44 @@
+/*
+ * SonarQube Erlang Plugin
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
+ * kende.tamas@gmail.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.erlang.eunit;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JacksonXmlRootElement(localName = "testsuites")
+public class EunitTestsuites {
+    @JacksonXmlProperty(localName = "testsuite")
+    @JacksonXmlElementWrapper(useWrapping = false)
+    private List<EunitTestsuite> testsuites;
+
+    public EunitTestsuites() {
+        this.testsuites = new ArrayList<>();
+    }
+
+    public List<EunitTestsuite> getTestsuites() {
+        return testsuites;
+    }
+}

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/eunit/EunitXmlSensor.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/eunit/EunitXmlSensor.java
@@ -79,9 +79,7 @@ public class EunitXmlSensor implements Sensor {
     FileSystem fileSystem = context.fileSystem();
     File reportsDir = new File(context.fileSystem().baseDir().getPath(),
             settings.getString(ErlangPlugin.EUNIT_FOLDER_KEY));
-    FilePredicate testFilePredicate = fileSystem.predicates().and(
-            fileSystem.predicates().hasType(InputFile.Type.TEST),
-            fileSystem.predicates().hasLanguage(Erlang.KEY));
+    FilePredicate testFilePredicate = fileSystem.predicates().hasLanguage(Erlang.KEY);
 
     LOG.debug("Parsing Eunit run results in Surefile format from folder {}", reportsDir);
 

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/eunit/EunitXmlSensor.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/eunit/EunitXmlSensor.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/eunit/EunitXmlSensor.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/eunit/EunitXmlSensor.java
@@ -69,6 +69,12 @@ public class EunitXmlSensor implements Sensor {
       } catch (IOException e) {
         LOG.error("Something went wrong during parsing xml report", e);
       }
+      try {
+        EunitTestsuites suites = mapper.readValue(file, EunitTestsuites.class);
+        ret.addAll(suites.getTestsuites());
+      } catch (IOException e) {
+        // intentionally left empty
+      }
     }
     return ret;
   }

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/eunit/EunitXmlSensor.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/eunit/EunitXmlSensor.java
@@ -96,8 +96,6 @@ public class EunitXmlSensor implements Sensor {
         saveIntegerMeasure(context, metricFinder, file, CoreMetrics.TEST_FAILURES_KEY, testReport.getFailures());
         saveIntegerMeasure(context, metricFinder, file, CoreMetrics.TEST_ERRORS_KEY, testReport.getErrors());
         saveLongMeasure(context, metricFinder, file, CoreMetrics.TEST_EXECUTION_TIME_KEY, testReport.getTimeInMs());
-        double successDensity = ((double) testReport.getErrors() + testReport.getFailures()) / testReport.getTests();
-        saveDoubleMeasure(context, metricFinder, file, CoreMetrics.TEST_SUCCESS_DENSITY_KEY, successDensity);
       }
     }
   }

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/eunit/package-info.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/eunit/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/package-info.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/xref/XrefReportParser.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/xref/XrefReportParser.java
@@ -1,0 +1,112 @@
+/*
+ * SonarQube Erlang Plugin
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
+ * kende.tamas@gmail.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.erlang.xref;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.rule.ActiveRule;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.batch.sensor.issue.NewIssue;
+import org.sonar.api.batch.sensor.issue.NewIssueLocation;
+import org.sonar.api.config.Settings;
+import org.sonar.api.rule.RuleKey;
+import org.sonar.plugins.erlang.ErlangPlugin;
+import org.sonar.plugins.erlang.dialyzer.ErlangRuleManager;
+
+import java.io.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Read and parse generated xref report
+ */
+public class XrefReportParser {
+
+  private static final String XREF_VIOLATION_ROW_REGEX = "Warning: ([^ :]*):([^/]*)/([0-9]+) .*";
+  private static final String REPO_KEY = XrefRuleDefinition.REPOSITORY_KEY;
+  private static final Logger LOG = LoggerFactory.getLogger(XrefReportParser.class);
+  private final SensorContext context;
+
+
+  XrefReportParser(SensorContext context) {
+    this.context = context;
+  }
+
+  public void xref(ErlangRuleManager ruleManager) {
+    /*
+      Read xref results
+     */
+    Settings settings = context.settings();
+    String reportFileName = null;
+
+    try {
+      File reportsDir = new File(context.fileSystem().baseDir().getPath(),
+              settings.getString(ErlangPlugin.EUNIT_FOLDER_KEY));
+
+      reportFileName = settings.getString(ErlangPlugin.XREF_FILENAME_KEY);
+      File file = new File(reportsDir, reportFileName);
+
+      FileInputStream fstream = new FileInputStream(file);
+      DataInputStream in = new DataInputStream(fstream);
+      BufferedReader xrefOutput = new BufferedReader(new InputStreamReader(in));
+      BufferedReader breader = new BufferedReader(xrefOutput);
+
+      String strLine;
+      Pattern pattern = Pattern.compile(XREF_VIOLATION_ROW_REGEX);
+      while ((strLine = breader.readLine()) != null) {
+        Matcher matcher = pattern.matcher(strLine);
+        if (!matcher.matches()){
+            continue;
+        }
+
+        String fileName = matcher.group(1);
+
+        String key = ruleManager.getRuleKeyByMessage(strLine);
+        RuleKey ruleKey = RuleKey.of(REPO_KEY, key);
+        ActiveRule rule = context.activeRules().find(ruleKey);
+        if (rule != null) {
+            String filePattern = "**/" + fileName + ".erl";
+            InputFile inputFile = context.fileSystem().inputFile(
+                    context.fileSystem().predicates().matchesPathPattern(filePattern));
+            if (inputFile != null) {
+                NewIssue issue = getNewIssue(strLine, ruleKey, inputFile);
+                issue.save();
+            }
+        }
+      }
+      breader.close();
+    } catch (FileNotFoundException e) {
+      LOG.warn("Xref file not found at: " + reportFileName + ", have you ran xref before analysis?", e);
+    } catch (IOException e) {
+      LOG.error("Error while trying to parse xref report at: " + reportFileName, e);
+    }
+  }
+
+  private NewIssue getNewIssue(String message, RuleKey ruleKey, InputFile inputFile) {
+    NewIssue issue = context.newIssue().forRule(ruleKey);
+    NewIssueLocation location = issue.newLocation()
+            .on(inputFile)
+            .message(message);
+
+    issue.at(location);
+    return issue;
+  }
+}

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/xref/XrefRuleDefinition.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/xref/XrefRuleDefinition.java
@@ -1,0 +1,46 @@
+/*
+ * SonarQube Erlang Plugin
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
+ * kende.tamas@gmail.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.erlang.xref;
+
+import com.google.common.base.Charsets;
+import org.sonar.api.server.rule.RulesDefinition;
+import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
+import org.sonar.plugins.erlang.core.Erlang;
+
+public class XrefRuleDefinition implements RulesDefinition {
+
+  public static final String REPOSITORY_NAME = "Xref";
+  public static final String REPOSITORY_KEY = "xref";
+  public static final String XREF_PATH = "/org/sonar/plugins/erlang/xref/rules.xml";
+
+  private final RulesDefinitionXmlLoader xmlLoader;
+
+  public XrefRuleDefinition(RulesDefinitionXmlLoader xmlLoader) {
+    this.xmlLoader = xmlLoader;
+  }
+
+  @Override
+  public void define(Context context) {
+    NewRepository repository = context.createRepository(REPOSITORY_KEY, Erlang.KEY).setName(REPOSITORY_NAME);
+    xmlLoader.load(repository, getClass().getResourceAsStream(XREF_PATH), Charsets.UTF_8.name());
+    repository.done();
+  }
+
+}

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/xref/XrefSensor.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/xref/XrefSensor.java
@@ -1,0 +1,57 @@
+/*
+ * SonarQube Erlang Plugin
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
+ * kende.tamas@gmail.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.erlang.xref;
+
+import org.sonar.api.batch.sensor.Sensor;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.batch.sensor.SensorDescriptor;
+import org.sonar.plugins.erlang.core.Erlang;
+import org.sonar.plugins.erlang.dialyzer.ErlangRuleManager;
+
+/**
+ * Calls the xref report parser saves violations to sonar
+ *
+ * @author tkende
+ */
+public class XrefSensor implements Sensor {
+
+  private ErlangRuleManager xrefRuleManager;
+
+  public XrefSensor() {
+    xrefRuleManager = new ErlangRuleManager(XrefRuleDefinition.XREF_PATH);
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName();
+  }
+
+  @Override
+  public void describe(SensorDescriptor descriptor) {
+    descriptor
+            .onlyOnLanguage(Erlang.KEY)
+            .name("Erlang Xref Sensor");
+  }
+
+  @Override
+  public void execute(SensorContext context) {
+    new XrefReportParser(context).xref(xrefRuleManager);
+  }
+}

--- a/sonar-erlang-plugin/src/main/resources/org/sonar/plugins/erlang/dialyzer/rules.xml
+++ b/sonar-erlang-plugin/src/main/resources/org/sonar/plugins/erlang/dialyzer/rules.xml
@@ -31,9 +31,7 @@
       <![CDATA[bin_construction]]>
     </description>
     <messages>
-      <message>Binary construction will fail since the ~s field ~s in
-        segment ~s has type ~s
-      </message>
+      <message>Binary construction will fail since the ~s field ~s in segment ~s has type ~s</message>
     </messages>
   </rule>
   <rule>
@@ -77,9 +75,7 @@
       <![CDATA[fun_app_args]]>
     </description>
     <messages>
-      <message>Fun application with arguments ~s will fail since the
-        function has type ~s
-      </message>
+      <message>Fun application with arguments ~s will fail since the function has type ~s</message>
     </messages>
   </rule>
   <rule>
@@ -90,9 +86,7 @@
       <![CDATA[fun_app_no_fun]]>
     </description>
     <messages>
-      <message>Fun application will fail since ~s :: ~s is not a function
-        of arity ~w
-      </message>
+      <message>Fun application will fail since ~s :: ~s is not a function of arity ~w</message>
     </messages>
   </rule>
   <rule>
@@ -129,9 +123,7 @@
       <![CDATA[guard_fail_pat]]>
     </description>
     <messages>
-      <message>Clause guard cannot succeed. The ~s was matched against the
-        type ~s
-      </message>
+      <message>Clause guard cannot succeed. The ~s was matched against the type ~s</message>
     </messages>
   </rule>
   <rule>
@@ -142,9 +134,7 @@
       <![CDATA[improper_list_constr]]>
     </description>
     <messages>
-      <message>Cons will produce an improper list since its 2nd argument is
-        ~s
-      </message>
+      <message>Cons will produce an improper list since its 2nd argument is ~s</message>
     </messages>
   </rule>
   <rule>
@@ -173,12 +163,8 @@
       <![CDATA[record_constr]]>
     </description>
     <messages>
-      <message>Record construction ~s violates the declared type of field
-        ~s
-      </message>
-      <message>Record construction violates the declared type for #~w{}
-        since ~s cannot be of type ~s
-      </message>
+      <message>Record construction ~s violates the declared type of field ~s</message>
+      <message>Record construction violates the declared type for #~w{} since ~s cannot be of type ~s</message>
     </messages>
   </rule>
   <rule>
@@ -200,9 +186,7 @@
       <![CDATA[record_match]]>
     </description>
     <messages>
-      <message>Matching of ~s tagged with a record name violates the
-        declared type of ~s
-      </message>
+      <message>Matching of ~s tagged with a record name violates the declared type of ~s</message>
     </messages>
   </rule>
   <rule>
@@ -214,9 +198,7 @@
     </description>
     <messages>
       <message>The ~s can never match the type ~s</message>
-      <message>The ~s can never match since previous clauses completely
-        covered the type ~s
-      </message>
+      <message>The ~s can never match since previous clauses completely covered the type ~s</message>
     </messages>
   </rule>
   <rule>
@@ -227,9 +209,7 @@
       <![CDATA[unmatched_return]]>
     </description>
     <messages>
-      <message>Expression produces a value of type ~s, but this value is
-        unmatched
-      </message>
+      <message>Expression produces a value of type ~s, but this value is unmatched</message>
     </messages>
   </rule>
   <rule>
@@ -252,9 +232,7 @@
       <![CDATA[contract_diff]]>
     </description>
     <messages>
-      <message>Type specification ~w:~w~s is not equal to the success
-        typing: ~w:~w~s
-      </message>
+      <message>Type specification ~w:~w~s is not equal to the success typing: ~w:~w~s</message>
     </messages>
   </rule>
   <rule>
@@ -265,9 +243,7 @@
       <![CDATA[contract_subtype]]>
     </description>
     <messages>
-      <message>Type specification ~w:~w~s is a subtype of the success
-        typing: ~w:~w~s
-      </message>
+      <message>Type specification ~w:~w~s is a subtype of the success typing: ~w:~w~s</message>
     </messages>
   </rule>
   <rule>
@@ -278,9 +254,7 @@
       <![CDATA[contract_supertype]]>
     </description>
     <messages>
-      <message>Type specification ~w:~w~s is a supertype of the success
-        typing: ~w:~w~s
-      </message>
+      <message>Type specification ~w:~w~s is a supertype of the success typing: ~w:~w~s</message>
     </messages>
   </rule>
   <rule>
@@ -291,9 +265,7 @@
       <![CDATA[contract_range]]>
     </description>
     <messages>
-      <message>The contract ~w:~w~s cannot be right because the inferred
-        return for ~w~s on line ~w is ~s
-      </message>
+      <message>The contract ~w:~w~s cannot be right because the inferred return for ~w~s on line ~w is ~s</message>
     </messages>
   </rule>
   <rule>
@@ -304,9 +276,7 @@
       <![CDATA[invalid_contract]]>
     </description>
     <messages>
-      <message>Invalid type specification for function ~w:~w/~w. The
-        success typing is ~s
-      </message>
+      <message>Invalid type specification for function ~w:~w/~w. The success typing is ~s</message>
     </messages>
   </rule>
   <rule>
@@ -317,10 +287,7 @@
       <![CDATA[extra_range]]>
     </description>
     <messages>
-      <message>The specification for ~w:~w/~w states that the function
-        might also return ~s but the inferred return
-        is ~s
-      </message>
+      <message>The specification for ~w:~w/~w states that the function might also return ~s but the inferred return is ~s</message>
     </messages>
   </rule>
   <rule>
@@ -331,10 +298,7 @@
       <![CDATA[overlapping_contract]]>
     </description>
     <messages>
-      <message>Overloaded contract has overlapping domains; such contracts
-        are currently unsupported and are simply
-        ignored
-      </message>
+      <message>Overloaded contract has overlapping domains; such contracts are currently unsupported and are simply ignored</message>
     </messages>
   </rule>
   <rule>
@@ -378,9 +342,7 @@
       <![CDATA[opaque_eq]]>
     </description>
     <messages>
-      <message>Attempt to test for equality between a term of type ~s and a
-        term of opaque type ~s
-      </message>
+      <message>Attempt to test for equality between a term of type ~s and a term of opaque type ~s</message>
     </messages>
   </rule>
   <rule>
@@ -402,9 +364,7 @@
       <![CDATA[opaque_match]]>
     </description>
     <messages>
-      <message>The attempt to match a term of type ~s against the ~s breaks
-        the opaqueness of ~s
-      </message>
+      <message>The attempt to match a term of type ~s against the ~s breaks the opaqueness of ~s</message>
     </messages>
   </rule>
   <rule>
@@ -415,9 +375,7 @@
       <![CDATA[opaque_neq]]>
     </description>
     <messages>
-      <message>Attempt to test for inequality between a term of type ~s and
-        a term of opaque type ~s
-      </message>
+      <message>Attempt to test for inequality between a term of type ~s and a term of opaque type ~s</message>
     </messages>
   </rule>
   <rule>
@@ -450,10 +408,7 @@
       <![CDATA[callback_type_mismatch]]>
     </description>
     <messages>
-      <message>The inferred return type of ~w/~w (~s) has nothing in common
-        with ~s, which is the expected return
-        type for the callback of ~w behaviour
-      </message>
+      <message>The inferred return type of ~w/~w (~s) has nothing in common with ~s, which is the expected return type for the callback of ~w behaviour</message>
     </messages>
   </rule>
   <rule>
@@ -464,10 +419,7 @@
       <![CDATA[callback_arg_type_mismatch]]>
     </description>
     <messages>
-      <message>The inferred type for the ~s argument of ~w/~w (~s) is not a
-        supertype of ~s, which is expected type
-        for this argument in the callback of the ~w behaviour
-      </message>
+      <message>The inferred type for the ~s argument of ~w/~w (~s) is not a supertype of ~s, which is expected type for this argument in the callback of the ~w behaviour</message>
     </messages>
   </rule>
   <rule>
@@ -478,10 +430,7 @@
       <![CDATA[callback_spec_type_mismatch]]>
     </description>
     <messages>
-      <message>The return type ~s in the specification of ~w/~w is not a
-        subtype of ~s, which is the expected return type for the callback of
-        ~w behaviour
-      </message>
+      <message>The return type ~s in the specification of ~w/~w is not a subtype of ~s, which is the expected return type for the callback of ~w behaviour</message>
     </messages>
   </rule>
   <rule>
@@ -492,10 +441,7 @@
       <![CDATA[callback_spec_arg_type_mismatch]]>
     </description>
     <messages>
-      <message>The specified type for the ~s argument of ~w/~w (~s) is not
-        a supertype of ~s, which is expected type for this argument in the
-        callback of the ~w behaviour
-      </message>
+      <message>The specified type for the ~s argument of ~w/~w (~s) is not a supertype of ~s, which is expected type for this argument in the callback of the ~w behaviour</message>
     </messages>
   </rule>
   <rule>

--- a/sonar-erlang-plugin/src/main/resources/org/sonar/plugins/erlang/profile-default.xml
+++ b/sonar-erlang-plugin/src/main/resources/org/sonar/plugins/erlang/profile-default.xml
@@ -212,5 +212,40 @@
       <key>D042</key>
       <priority>MAJOR</priority>
     </rule>
+    <rule>
+      <repositoryKey>xref</repositoryKey>
+      <key>X001</key>
+      <priority>MAJOR</priority>
+    </rule>
+    <rule>
+      <repositoryKey>xref</repositoryKey>
+      <key>X002</key>
+      <priority>MAJOR</priority>
+    </rule>
+    <rule>
+      <repositoryKey>xref</repositoryKey>
+      <key>X003</key>
+      <priority>MAJOR</priority>
+    </rule>
+    <rule>
+      <repositoryKey>xref</repositoryKey>
+      <key>X004</key>
+      <priority>MAJOR</priority>
+    </rule>
+    <rule>
+      <repositoryKey>xref</repositoryKey>
+      <key>X005</key>
+      <priority>MAJOR</priority>
+    </rule>
+    <rule>
+      <repositoryKey>xref</repositoryKey>
+      <key>X006</key>
+      <priority>MAJOR</priority>
+    </rule>
+    <rule>
+      <repositoryKey>xref</repositoryKey>
+      <key>X007</key>
+      <priority>MAJOR</priority>
+    </rule>
   </rules>
 </profile>

--- a/sonar-erlang-plugin/src/main/resources/org/sonar/plugins/erlang/xref/rules.xml
+++ b/sonar-erlang-plugin/src/main/resources/org/sonar/plugins/erlang/xref/rules.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rules>
+  <rule>
+    <key>X001</key>
+    <name><![CDATA[Undefined function calls]]></name>
+    <internalKey>undefined_function_calls</internalKey>
+    <description>
+      <![CDATA[Undefined function calls]]>
+    </description>
+    <messages>
+      <message>Warning: ~s:~s/~s calls undefined function ~s:~s/~s (Xref)</message>
+    </messages>
+  </rule>
+  <rule>
+    <key>X002</key>
+    <name><![CDATA[Undefined functions]]></name>
+    <internalKey>undefined_functions</internalKey>
+    <description>
+      <![CDATA[Undefined functions]]>
+    </description>
+    <messages>
+      <message>Warning: ~s:~s/~s is undefined function (Xref)</message>
+    </messages>
+  </rule>
+  <rule>
+    <key>X003</key>
+    <name><![CDATA[Locals not used]]></name>
+    <internalKey>locals_not_used</internalKey>
+    <description>
+      <![CDATA[Locals not used]]>
+    </description>
+    <messages>
+      <message>Warning: ~s:~s/~s is unused local function (Xref)</message>
+    </messages>
+  </rule>
+  <rule>
+    <key>X004</key>
+    <name><![CDATA[Exports not used]]></name>
+    <internalKey>exports_not_used</internalKey>
+    <description>
+      <![CDATA[Exports not used]]>
+    </description>
+    <messages>
+      <message>Warning: ~s:~s/~s is unused export (Xref)</message>
+    </messages>
+  </rule>
+  <rule>
+    <key>X005</key>
+    <name><![CDATA[Deprecated function calls]]></name>
+    <internalKey>deprecated_function_calls</internalKey>
+    <description>
+      <![CDATA[Deprecated function calls]]>
+    </description>
+    <messages>
+      <message>Warning: ~s:~s/~s calls deprecated function ~s:~s/~s (Xref)</message>
+    </messages>
+  </rule>
+  <rule>
+    <key>X006</key>
+    <name><![CDATA[Deprecated functions]]></name>
+    <internalKey>deprecated_functions</internalKey>
+    <description>
+      <![CDATA[Deprecated functions]]>
+    </description>
+    <messages>
+      <message>Warning: ~s:~s/~s is deprecated function (Xref)</message>
+    </messages>
+  </rule>
+  <rule>
+    <key>X007</key>
+    <name><![CDATA[Xref other]]></name>
+    <internalKey>xref_other</internalKey>
+    <description>
+      <![CDATA[Xref other]]>
+    </description>
+    <messages>
+      <message>Warning: ~s:~s/~s - ~s xref check: ~s (Xref)</message>
+    </messages>
+  </rule>
+</rules>

--- a/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/ErlangPluginTest.java
+++ b/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/ErlangPluginTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/ErlangProfileTest.java
+++ b/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/ErlangProfileTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/ErlangSquidSensorTest.java
+++ b/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/ErlangSquidSensorTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/ProjectUtil.java
+++ b/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/ProjectUtil.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/checks/ErlangChecksRuleDefinitionTest.java
+++ b/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/checks/ErlangChecksRuleDefinitionTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/cover/CoverCoverageSensorTest.java
+++ b/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/cover/CoverCoverageSensorTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/cover/CoverDataFileParserTest.java
+++ b/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/cover/CoverDataFileParserTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/cover/LCOVParserTest.java
+++ b/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/cover/LCOVParserTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/dialyzer/DialyzerRuleDefinitionTest.java
+++ b/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/dialyzer/DialyzerRuleDefinitionTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/dialyzer/DialyzerSensorTest.java
+++ b/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/dialyzer/DialyzerSensorTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/eunit/EunitXmlPOJOTest.java
+++ b/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/eunit/EunitXmlPOJOTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/eunit/EunitXmlSensorTest.java
+++ b/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/eunit/EunitXmlSensorTest.java
@@ -61,7 +61,6 @@ public class EunitXmlSensorTest {
     when(metricFinder.<Integer>findByKey(CoreMetrics.TEST_ERRORS_KEY)).thenReturn(CoreMetrics.TEST_ERRORS);
     when(metricFinder.<Integer>findByKey(CoreMetrics.TEST_FAILURES_KEY)).thenReturn(CoreMetrics.TEST_FAILURES);
     when(metricFinder.<Long>findByKey(CoreMetrics.TEST_EXECUTION_TIME_KEY)).thenReturn(CoreMetrics.TEST_EXECUTION_TIME);
-    when(metricFinder.<Double>findByKey(CoreMetrics.TEST_SUCCESS_DENSITY_KEY)).thenReturn(CoreMetrics.TEST_SUCCESS_DENSITY);
     new EunitXmlSensor(metricFinder).execute(context);
   }
 
@@ -83,6 +82,5 @@ public class EunitXmlSensorTest {
     assertThat(context.measure("test:test/erlcount_tests.erl", CoreMetrics.TEST_ERRORS_KEY).value()).isEqualTo(0);
     assertThat(context.measure("test:test/erlcount_tests.erl", CoreMetrics.TEST_FAILURES_KEY).value()).isEqualTo(1);
     assertThat(context.measure("test:test/erlcount_tests.erl", CoreMetrics.TEST_EXECUTION_TIME_KEY).value()).isEqualTo(133L);
-    assertThat(context.measure("test:test/erlcount_tests.erl", CoreMetrics.TEST_SUCCESS_DENSITY_KEY).value()).isEqualTo(1/7.0 );
   }
 }

--- a/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/eunit/EunitXmlSensorTest.java
+++ b/sonar-erlang-plugin/src/test/java/org/sonar/plugins/erlang/eunit/EunitXmlSensorTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sslr-erlang-toolkit/src/main/java/org/sonar/erlang/sslr/toolkit/ErlangConfigurationModel.java
+++ b/sslr-erlang-toolkit/src/main/java/org/sonar/erlang/sslr/toolkit/ErlangConfigurationModel.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sslr-erlang-toolkit/src/main/java/org/sonar/erlang/sslr/toolkit/ErlangToolkit.java
+++ b/sslr-erlang-toolkit/src/main/java/org/sonar/erlang/sslr/toolkit/ErlangToolkit.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/sslr-erlang-toolkit/src/main/java/org/sonar/erlang/sslr/toolkit/package-info.java
+++ b/sslr-erlang-toolkit/src/main/java/org/sonar/erlang/sslr/toolkit/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Erlang Plugin
- * Copyright (C) 2012-2017 Tamas Kende
+ * Copyright (C) 2012-2018 Tamas Kende; Denes Hegedus (Cursor Insight Ltd.)
  * kende.tamas@gmail.com
  *
  * This program is free software; you can redistribute it and/or

--- a/travis.sh
+++ b/travis.sh
@@ -17,14 +17,16 @@ CI)
 IT)
   installTravisTools
 
-  mvn package -Dsource.skip=true -Denforcer.skip=true -Danimal.sniffer.skip=true -Dmaven.test.skip=true
+  mvn package -Dsource.skip=true -Denforcer.skip=true -Danimal.sniffer.skip=true -Dmaven.test.skip=true \
+    -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
   if [ "$SQ_VERSION" == "DEV" ]; then
     build_snapshot "SonarSource/sonarqube"
   fi
 
   cd its/plugin
-  mvn -Dsonar.runtimeVersion="$SQ_VERSION" -Dmaven.test.redirectTestOutputToFile=false install
+  mvn -Dsonar.runtimeVersion="$SQ_VERSION" -Dmaven.test.redirectTestOutputToFile=false \
+    -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn install
   ;;
 
 *)


### PR DESCRIPTION
This pull request is based on https://github.com/SonarQubeCommunity/sonar-erlang/pull/29

These commits include:
* Parse the surefire output of rebar3 common test runs
* Fix parsing of `rebar3 dialyzer` output
* Add sensor for the output of `rebar3 xref`

I had problems with the license check in the new files as it allows only one contributor in the `pom.xml` so there is a commit that disables it with `-Dlicense.skip=true`. Is there any better way to allow more contributors?