### PR TITLE
Enable Erlang 21+

### DIFF
--- a/erlang-squid/src/main/java/org/sonar/erlang/parser/ErlangGrammarImpl.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/parser/ErlangGrammarImpl.java
@@ -766,7 +766,7 @@ public enum ErlangGrammarImpl implements GrammarRuleKey {
     b.rule(catchPatternStatements).is(catchPatternStatement, b.zeroOrMore(semi, catchPatternStatement));
     b.rule(catchPatternStatement).is(catchPattern, b.optional(guardSequenceStart), arrow, statements);
     b.rule(pattern).is(assignmentExpression);
-    b.rule(catchPattern).is(b.optional(atomOrIdentifier, colon), expression);
+    b.rule(catchPattern).is(b.optional(atomOrIdentifier, colon), expression, b.optional(colon, identifier));
 
     b.rule(guardSequenceStart).is(whenKeyword, guardSequence);
 

--- a/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangParserStatementTest.java
+++ b/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangParserStatementTest.java
@@ -89,6 +89,7 @@ public class ErlangParserStatementTest {
     assertThat(b.rule(ErlangGrammarImpl.statements))
       .matches(code("try Exprs of Pattern when GuardSeq -> Body after AfterBody end"))
       .matches(code("try Exprs catch ExpressionPattern -> ExpressionBody after AfterBody end"))
+      .matches(code("try Exprs catch ExpressionPattern:ExceptionBody:Stacktrace -> ExpressionBody after AfterBody end"))
       .matches(code("try Exprs after AfterBody end"))
       .matches(code("try", "{ok,Bin} = file:read(F, 1024*1024),", "binary_to_term(Bin)", "after",
         "file:close(F)", "end"))

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/ErlangSquidSensor.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/ErlangSquidSensor.java
@@ -125,18 +125,6 @@ public class ErlangSquidSensor implements Sensor {
 
   private void saveMeasures(SensorContext context, InputFile sonarFile, SourceFile squidFile) {
     NewMeasure<Serializable> m = context.newMeasure();
-    m.forMetric(metricFinder.findByKey(CoreMetrics.FILES_KEY))
-            .on(sonarFile)
-            .withValue(squidFile.getInt(ErlangMetric.FILES))
-            .save();
-
-    m = context.newMeasure();
-    m.forMetric(metricFinder.findByKey(CoreMetrics.LINES_KEY))
-            .on(sonarFile)
-            .withValue(squidFile.getInt(ErlangMetric.LINES))
-            .save();
-
-    m = context.newMeasure();
     m.forMetric(metricFinder.findByKey(CoreMetrics.NCLOC_KEY))
             .on(sonarFile)
             .withValue(squidFile.getInt(ErlangMetric.LINES_OF_CODE))


### PR DESCRIPTION
This PR enables us to use `sonar-erlang` for projects including the new `catch Class:Exception:Stacktrace ...` syntax which was introduced in Erlang 21.

It also removes some unnecessary, redundant metrics.